### PR TITLE
Add SQL injection fix from v0.13.0

### DIFF
--- a/lib/administrate/order.rb
+++ b/lib/administrate/order.rb
@@ -2,7 +2,7 @@ module Administrate
   class Order
     def initialize(attribute = nil, direction = nil)
       @attribute = attribute
-      @direction = direction || :asc
+      @direction = sanitize_direction(direction) || :asc
     end
 
     def apply(relation)
@@ -34,6 +34,13 @@ module Administrate
 
     attr_reader :attribute
 
+    # Added from v0.13.0 to prevent SQL injection
+    # https://github.com/thoughtbot/administrate/security/advisories/GHSA-2p5p-m353-833w
+    def sanitize_direction(direction)
+      return unless %w[asc desc].include?(direction.to_s)
+      direction.to_sym
+    end
+
     def reversed_direction_param_for(attr)
       if ordered_by?(attr)
         opposite_direction
@@ -43,7 +50,7 @@ module Administrate
     end
 
     def opposite_direction
-      direction.to_sym == :asc ? :desc : :asc
+      direction == :asc ? :desc : :asc
     end
 
     def order_by_association(relation)

--- a/spec/lib/administrate/order_spec.rb
+++ b/spec/lib/administrate/order_spec.rb
@@ -50,6 +50,17 @@ describe Administrate::Order do
         expect(relation).to have_received(:reorder).with("table_name.name desc")
         expect(ordered).to eq(relation)
       end
+
+      it "sanitizes arbitary direction parameters" do
+        order = Administrate::Order.new(:name, :foo)
+        relation = relation_with_column(:name)
+        allow(relation).to receive(:reorder).and_return(relation)
+
+        ordered = order.apply(relation)
+
+        expect(relation).to have_received(:reorder).with("table_name.name asc")
+        expect(ordered).to eq(relation)
+      end
     end
 
     context "when relation has_many association" do


### PR DESCRIPTION
Addresses: https://github.com/thoughtbot/administrate/security/advisories/GHSA-2p5p-m353-833w without pulling in additional changes that would require extensive regression testing on the artlook platform.

Given the chance that this forked library _might_ be nearing EOL, I did not think it was worth the effort to port over all of the changes from [v0.13.0](https://github.com/thoughtbot/administrate/releases/tag/v0.13.0)